### PR TITLE
game works well on recent Intel drivers (Mesa 22.3+)

### DIFF
--- a/language/en/interface.json
+++ b/language/en/interface.json
@@ -570,7 +570,7 @@
 			"difficultyLevel": "Difficulty: %{count}"
 		},
 		"loadScreen": {
-			"intelGpuWarning": "%{textColor}You are using the integrated %{warnColor}Intel graphics%{textColor} card.     It's currently %{warnColor}unsupported, the game won't work properly."
+			"intelGpuWarning": "%{textColor}You are using the integrated %{warnColor}Intel graphics%{textColor} card.     It's currently %{warnColor}unsupported."
 		},
 		"initialSpawn": {
 			"ready": "Ready",


### PR DESCRIPTION
Reflect reality. On Recent Mesa (22.3+, 23.0 or later) game works flawlessly on Intel cards.